### PR TITLE
增加Docker镜像支持arm

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,3 +36,7 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/parse-video:latest
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64/v8


### PR DESCRIPTION
家里的Linux是arm的，但是大佬提供的只有amd64的，所以增加了一下arm64的支持，自测没有问题。家里的设备：armbian
，[1fe2be14/parse-video](https://hub.docker.com/r/1fe2be14/parse-video)可以在这里做进一步的验证。