### PR TITLE
refactor: 使用embed file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 .idea
 .idea/
 .fleet/
+node_modules
+.netlify
+package.json
+package-lock.json

--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"embed"
+	"html/template"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -19,10 +22,18 @@ type HttpResponse struct {
 	Data interface{} `json:"data"`
 }
 
+//go:embed templates/*
+var files embed.FS
+
 func main() {
 	r := gin.Default()
 
-	r.LoadHTMLGlob("templates/*")
+	sub, err := fs.Sub(files, "templates")
+	if err != nil {
+		panic(err)
+	}
+	tmpl := template.Must(template.ParseFS(sub, "*.tmpl"))
+	r.SetHTMLTemplate(tmpl)
 	r.GET("/", func(c *gin.Context) {
 		c.HTML(200, "index.tmpl", gin.H{
 			"title": "github.com/wujunwei928/parse-video Demo",


### PR DESCRIPTION
使用embed可以将模板文件打进可执行文件,减少依赖,部署更方便,也更容易部署成serverless函数