### PR TITLE
fix: 修复皮皮虾解析接口

### DIFF
--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/png" href="favicon.png">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mdui@1.0.0/dist/css/mdui.min.css"/>
 <script src="https://cdn.jsdelivr.net/npm/mdui@1.0.0/dist/js/mdui.min.js"></script>
-<script src="https://cdn.bootcss.com/jquery/2.1.4/jquery.min.js"></script>
+<script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-M/jquery/2.1.4/jquery.min.js"></script>
 </head>
 <body class="mdui-theme-primary-indigo mdui-theme-accent-pink">
 <style>


### PR DESCRIPTION
- 修复了皮皮虾解析接口(采用APP端 `cell_comment` 接口实现)
- `jquery` cdn 更换为 字节cdn (bootcss https 证书到期)

## preview

![image](https://github.com/user-attachments/assets/67bb183b-ff65-48d8-99ce-d1e6ff389edc)
